### PR TITLE
Add content security to configuration editor. Change explorer toolbar…

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "commands": [
             {
                 "category": "RHAMT",
-                "command": "rhamt.createConfiguration",
+                "command": "rhamt.newConfiguration",
                 "title": "New Configuration",
                 "icon": {
                     "light": "resources/light/add.svg",
@@ -97,10 +97,6 @@
             {
                 "command": "rhamt.deleteResults",
                 "title": "Delete"
-            },
-            {
-                "command": "rhamt.newConfiguration",
-                "title": "New Configuration"
             }
         ],
         "configuration": [
@@ -136,7 +132,7 @@
         "menus": {
             "view/title": [
                 {
-                    "command": "rhamt.createConfiguration",
+                    "command": "rhamt.newConfiguration",
                     "when": "view == rhamtExplorerView",
                     "group": "navigation"
                 }

--- a/src/editor/configurationEditor.ts
+++ b/src/editor/configurationEditor.ts
@@ -44,6 +44,13 @@ export class ConfigurationEditor {
         return `
             <!DOCTYPE html>
             <html>
+                <head>
+                <meta
+                    http-equiv="Content-Security-Policy"
+                    content="
+                    default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';"
+                />
+                </head>
                 <body style="margin:0px;padding:0px;overflow:hidden">
                     <iframe src="${location}"
                         frameborder="0" style="overflow:hidden;overflow-x:hidden;overflow-y:hidden;height:100%;width:100%;position:absolute;top:0px;left:0px;right:0px;bottom:0px" height="100%" width="100%"></iframe>


### PR DESCRIPTION
… 'new configuration' handler to open newly created configuration in editor instead of prompting a wizard.