### PR TITLE
Don't show error notification if a Diff editor isn't found after appl…

### DIFF
--- a/src/quickfix/diff.ts
+++ b/src/quickfix/diff.ts
@@ -109,10 +109,5 @@ export class Diff {
                 vscode.window.showErrorMessage(msg);
             }
         }
-        else {
-            const msg = `could not find diff editor for quickfix file`;
-            console.log(msg);
-            vscode.window.showErrorMessage(msg);
-        }
     }
 }


### PR DESCRIPTION
…ying a quickfix (it might not have been opened).