### PR TITLE
Update 7.2.0 bugs to make it compatible with mta-cli

### DIFF
--- a/.github/workflows /ci.yml
+++ b/.github/workflows /ci.yml
@@ -1,0 +1,34 @@
+name: Basic CI
+
+on:
+  push:
+    branches:
+      - "7.2.0" # Trigger only on pushes to the master branch
+
+  pull_request:
+    branches:
+      - "7.2.0" # Trigger on pull requests targeting the master branch
+
+jobs:
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest # Use Ubuntu for the runner
+
+    steps:
+      # Step 1: Checkout the code
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # Step 2: Set up Node.js
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "16" # Specify the Node.js version
+
+      # Step 3: Install dependencies
+      - name: Install dependencies
+        run: npm install
+
+      # Step 4: Compile the project
+      - name: Compile the project
+        run: npm run compile

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mta-vscode-extension",
-    "version": "7.1.1",
+    "version": "7.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mta-vscode-extension",
-            "version": "7.1.1",
+            "version": "7.2.0",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "mta-vscode-extension",
     "displayName": "Migration Toolkit for Applications (MTA)",
     "description": "Migration Toolkit for Applications (MTA)",
-    "version": "7.1.1",
+    "version": "7.2.0",
     "license": "epl-2.0",
     "publisher": "redhat",
     "author": "Red Hat",

--- a/resources/help.json
+++ b/resources/help.json
@@ -216,7 +216,8 @@
         "description": "The location of the generated analysis results.",
         "type": "String",
         "ui-type": ["single"],
-        "required": false
+        "required": true,
+        "editable": false
       },
       {
         "name": "analyze-known-libraries",

--- a/src/editor/configurationView.ts
+++ b/src/editor/configurationView.ts
@@ -347,8 +347,9 @@ export class ConfigurationView {
 
         // cloning...
         if (cloning) {
-            if (vscode.workspace.workspaceFolders) {
-                const workspaceFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
+            if (this.configuration.getinput()) {
+                const inputPaths = this.configuration.getinput();
+                const workspaceFolder = vscode.Uri.joinPath(vscode.Uri.file(inputPaths[0])).fsPath;
                 const folderName = data.value.substring(data.value.lastIndexOf('/') + 1);
                 const cloneCommand = {repo: data.value, folderName, config: this.configuration, workspaceFolder};
                 vscode.commands.executeCommand('rhamt.downloadGitRepo', cloneCommand).then((result:any) => {

--- a/src/server/analyzerModel.ts
+++ b/src/server/analyzerModel.ts
@@ -87,9 +87,12 @@ export class RhamtConfiguration {
     }
 
     sourceBase(): string {
-        return 'file:///tmp/source-code/';
+        return 'file:///opt/input/source';
     }
-
+    getinput(): string {
+        if (!this.options['input']) return undefined;
+        return this.options['input'];
+    }
     getResultsLocation(): string {
         if (!this.options['output']) return undefined;
         return path.resolve(this.options['output'], 'results.xml');

--- a/src/server/analyzerResults.ts
+++ b/src/server/analyzerResults.ts
@@ -53,8 +53,15 @@ export class AnalyzerResults {
                     if (incidents) {
                         incidents.forEach(incident => {
                             const file = (incident.uri as string).replace(this.config.sourceBase(), '');
-                            const root = vscode.workspace.workspaceFolders[0];
-                            const fileUri = vscode.Uri.joinPath(root.uri, file);
+                            const root = vscode.workspace.workspaceFolders?.[0]; 
+                            let fileUri: vscode.Uri;
+                            const inputPaths = this.config.getinput(); 
+                            if (Array.isArray(inputPaths) && inputPaths[0]) {
+                                fileUri = vscode.Uri.joinPath(vscode.Uri.file(inputPaths[0]), file);
+                            } else if (root) {
+                                fileUri = vscode.Uri.joinPath(root.uri, file);
+                            } 
+                     
                             try {
                                 const hint = {
                                     type: IIssueType.Hint,

--- a/src/tree/configurationNode.ts
+++ b/src/tree/configurationNode.ts
@@ -131,18 +131,20 @@ export class ConfigurationNode extends AbstractNode<ConfigurationItem> implement
     }
 
     private buildResourceNodes(file: string): void {
-        const root = workspace.workspaceFolders[0]; 
+        const inputPaths = this.config.getinput(); 
+        const root = Uri.file(inputPaths[0]);
+       // const root = workspace.workspaceFolders[0]; 
 
-        if (!this.childNodes.has(root.uri.fsPath)) {
+        if (!this.childNodes.has(root.fsPath)) {
             const folder = new FolderNode(
                 this.config,
-                root.uri.fsPath,
+                root.fsPath,
                 this.modelService,
                 this.onNodeCreateEmitter,
                 this.dataProvider,
                 this);
-            this.childNodes.set(root.uri.fsPath, folder);
-            this.resourceNodes.set(root.uri.fsPath, folder);
+            this.childNodes.set(root.fsPath, folder);
+            this.resourceNodes.set(root.fsPath, folder);
         }
         
         


### PR DESCRIPTION
Fixes: 
- Updates missing file path ([MTA-3851](https://issues.redhat.com/browse/MTA-3851))
- Unchecking the output option clears the output path ([MTA-3850](https://issues.redhat.com/browse/MTA-3850))
- VSCode extension path for analyzed files contains /opt/input/source ([MTA-3814](https://issues.redhat.com/browse/MTA-3814))
-  Analysis tree is generated based on input instead opened project in the workspace.